### PR TITLE
Custom metric name

### DIFF
--- a/apm-hosts.tf
+++ b/apm-hosts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "apm_hosts" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Estimated APM Hosts Usage"
   query            = "avg(${var.apm_hosts_evaluation_period}):sum:datadog.estimated_usage.apm_hosts{${local.apm_hosts_filter}} > ${var.apm_hosts_critical}"

--- a/apm-spans.tf
+++ b/apm-spans.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "apm_spans" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Estimated APM Analyzed Spans Usage"
   query            = "sum(${var.apm_spans_evaluation_period}):sum:datadog.estimated_usage.apm.indexed_spans{${local.apm_spans_filter}}.as_count() > ${var.apm_spans_critical}"

--- a/containers.tf
+++ b/containers.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "containers" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Estimated Containers Usage"
   query            = "avg(${var.containers_evaluation_period}):sum:datadog.estimated_usage.containers{${local.containers_filter}} > ${var.containers_critical}"

--- a/custom-metrics.tf
+++ b/custom-metrics.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "custom_metrics" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Estimated Custom Metrics Usage"
   query            = "avg(${var.custom_metrics_evaluation_period}):sum:datadog.estimated_usage.metrics.custom{${local.custom_metrics_filter}} > ${var.custom_metrics_critical}"

--- a/hosts.tf
+++ b/hosts.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "hosts" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Estimated Hosts Usage"
   query            = "avg(${var.hosts_evaluation_period}):sum:datadog.estimated_usage.hosts{${local.hosts_filter}} > ${var.hosts_critical}"

--- a/logs-indexed.tf
+++ b/logs-indexed.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "logs_indexed" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Indexed Logs"
   query            = "sum(${var.logs_indexed_evaluation_period}):sum:datadog.logs.indexed{${local.logs_indexed_filter}}.as_count() > ${var.logs_indexed_critical}"

--- a/logs-ingestion-4h.tf
+++ b/logs-ingestion-4h.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "logs_ingestion_4h" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Logs ingestion high"
   query            = "sum(${var.logs_ingestion_4h_evaluation_period}):sum:datadog.estimated_usage.logs.ingested_bytes{${local.logs_ingestion_4h_filter}}.as_count() > ${var.logs_ingestion_4h_critical}"

--- a/logs-ingestion.tf
+++ b/logs-ingestion.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "logs_ingestion" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5.2"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.6.0"
 
   name             = "Daily Logs Ingestion"
   query            = "sum(${var.logs_ingestion_evaluation_period}):sum:datadog.estimated_usage.logs.ingested_bytes{${local.logs_ingestion_filter}}.as_count() > ${var.logs_ingestion_critical}"

--- a/logs-metrics-generation.tf
+++ b/logs-metrics-generation.tf
@@ -22,7 +22,7 @@ resource "datadog_logs_metric" "ingested_bytes" {
 }
 
 resource "datadog_logs_metric" "ingested_events" {
-  name = "datadog.estimated_usage.logs.ingested_events"
+  name = "custom_datadog.estimated_usage.logs.ingested_events"
 
   compute {
     aggregation_type = "count"

--- a/logs-metrics-generation.tf
+++ b/logs-metrics-generation.tf
@@ -1,5 +1,5 @@
 resource "datadog_logs_metric" "ingested_bytes" {
-  name = "datadog.estimated_usage.logs.ingested_bytes"
+  name = "custom_datadog.estimated_usage.logs.ingested_bytes"
 
   compute {
     aggregation_type = "distribution"


### PR DESCRIPTION
Custom Metric Names aren't allowed to start with `datadog.` anymore